### PR TITLE
Xnode - switchover to openmesh org

### DIFF
--- a/src/xnodes/utils/constants.ts
+++ b/src/xnodes/utils/constants.ts
@@ -50,58 +50,42 @@ export const sourceList = [
 ];
 
 export const defaultSourcePayload = {
-  name: 'connectors',
   namespace: 'openmesh',
   args: '--set image.repository=gdafund/collector --set image.tag=20230406.7',
   command: 'helm upgrade --install',
-  helmChartName: 'l3a-connector',
-  helmRepoName: 'L3A-Protocol',
-  helmRepoUrl:
-    'https://raw.githubusercontent.com/L3A-Protocol/gda-helm-repo/main/',
+  helmChartNameSuffix: '-connector',
+  helmRepoName: 'openmesh-network',
+  helmRepoUrl: 'https://raw.githubusercontent.com/Openmesh-Network/gda-helm-repo/main/',
   ingress: {
     enabled: false,
     hostname: null,
   },
-  helmValuesRepo: 'github.com/L3A-Protocol/gda-helm-charts.git',
-  pathToChart: 'charts',
 };
 
 export const defaultWSPayload = {
-  name: 'websocket_server',
   namespace: 'openmesh',
   args: '--set image.repository=gdafund/l3_atom --set image.tag=0.1.0',
   command: 'helm upgrade --install',
-  helmChartName: 'l3a-app',
-  helmRepoName: 'L3A-Protocol',
-  helmRepoUrl:
-    'https://raw.githubusercontent.com/L3A-Protocol/gda-helm-repo/main/',
-  helmValuesRepo: 'github.com/L3A-Protocol/gda-helm-charts.git',
+  helmChartNameSuffix: '-app',
+  helmRepoName: 'openmesh-network',
+  helmRepoUrl: 'https://raw.githubusercontent.com/Openmesh-Network/gda-helm-repo/main/',
   ingress: {
     enabled: true,
     hostname: 'ws',
   },
-  pathToChart: 'charts',
   workloads: ['websocketserver'],
 };
 
 export const defaultStreamProcessorPayload = {
-  name: 'stream_processor',
   namespace: 'openmesh',
   args: '--set image.repository=gdafund/l3_atom --set image.tag=0.1.0',
-
   command: 'helm upgrade --install',
-  repositoryName: 'L3A-Protocol',
-  repository:
-    'https://raw.githubusercontent.com/L3A-Protocol/gda-helm-repo/main/',
-  helmChartName: 'l3a-app',
-  helmRepoName: 'L3A-Protocol',
-  helmRepoUrl:
-    'https://raw.githubusercontent.com/L3A-Protocol/gda-helm-repo/main/',
-  helmValuesRepo: 'github.com/L3A-Protocol/gda-helm-charts.git',
+  helmChartNameSuffix: '-app',
+  helmRepoName: 'openmesh-network',
+  helmRepoUrl: 'https://raw.githubusercontent.com/Openmesh-Network/gda-helm-repo/main/',
   ingress: {
     enabled: false,
     hostname: null,
   },
-  pathToChart: 'charts',
   workloads: ['streamprocessor'],
 };

--- a/src/xnodes/xnodes.service.ts
+++ b/src/xnodes/xnodes.service.ts
@@ -219,7 +219,7 @@ export class XnodesService {
       const fetchBuildId = async () => {
         try {
           const response = await axios.get(
-            `https://dev.azure.com/gdafund/L3/_apis/build/builds?tagFilters=${tagId}`,
+            `https://dev.azure.com/openmesh-network/xnode-deploy/_apis/build/builds?tagFilters=${tagId}`,
             {
               headers: {
                 Authorization: `Basic ${encodedCredentials}`,
@@ -268,7 +268,7 @@ export class XnodesService {
       const fetchLogs = async () => {
         try {
           const response = await axios.get(
-            `https://dev.azure.com/gdafund/L3/_apis/build/builds/${buildId}/logs?api-version=7.1-preview.2`,
+            `https://dev.azure.com/openmesh-network/xnode-deploy/_apis/build/builds/${buildId}/logs?api-version=7.1-preview.2`,
             {
               headers: {
                 Authorization: `Basic ${encodedCredentials}`,


### PR DESCRIPTION
- Change feature payload data structure
- Change endpoint for build logs
- Unable to find the webhook configuration string. It should be "https://dev.azure.com/openmesh-network/_apis/public/distributedtask/webhooks/xnode/?api-version=6.0-preview"