### PR TITLE
Feature/unit controller integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,6 @@ DEEPLINK_TEAM_SIGNATURE=""
 VIEW_PRIVATE_KEY=""
 WEB3_URL_PROVIDER=""
 TASK_CONTRACT_ADDRESS=""
-COVALENT_API_BASE_URL=""
-COVALENT_API_KEY=""
-PINATA_API_KEY=""
-PINATA_SECRET_API_KEY=""
 API_TOKEN_KEY=""
 IPFS_BASE_URL=""
 XU_NFT_CONTRACT_ADDRESS=""
@@ -18,7 +14,8 @@ XU_CONTROLLER_KEY=""
 # 1 for true, 0 for false
 XU_CONTROLLER_ENABLE=0
 
-
+# Self-referential, is the remote for any xnode-admin deployed through this dpl.
+XNODE_API_URL="http://remote-dpl.placeholder/xnodes/functions"
 # Hivelocity key, currently used to mock controller
 HIVELOCITY_KEY=
 # Comma separated list of hivelocity keys, will be used to round-robbin deployments in case the server hasn't been added.

--- a/src/xnodes/dto/xnodes.dto.ts
+++ b/src/xnodes/dto/xnodes.dto.ts
@@ -28,20 +28,20 @@ enum XnodeEnum {
 
 export class CreateXnodeDto {
   @IsNotEmpty()
-  @MaxLength(1000)
+  @MaxLength(100)
   @IsString()
   @ApiProperty({
     description: 'The xnode name',
-    maxLength: 1000,
+    maxLength: 100,
   })
   name: string;
 
   @IsNotEmpty()
-  @MaxLength(1000)
+  @MaxLength(100)
   @IsString()
   @ApiProperty({
     description: 'The xnode location',
-    maxLength: 1000,
+    maxLength: 100,
   })
   location: string;
 
@@ -97,11 +97,11 @@ export class CreateXnodeDto {
 
 export class XnodeHeartbeatDto {
   @IsNotEmpty()
-  @MaxLength(1000)
+  @MaxLength(100)
   @IsString()
   @ApiProperty({
     description: 'The xnode\'s id',
-    maxLength: 1000,
+    maxLength: 100,
   })
   id: string;
 
@@ -157,31 +157,31 @@ export class XnodeHeartbeatDto {
 
 export class GetXnodeServiceDto {
   @IsNotEmpty()
-  @MaxLength(1000)
+  @MaxLength(5000)
   @IsString()
   @ApiProperty({
     description: 'The xnode\'s id',
-    maxLength: 1000,
+    maxLength: 5000,
   })
   id: string;
 }
 
 export class PushXnodeServiceDto {
   @IsNotEmpty()
-  @MaxLength(1000)
+  @MaxLength(5000)
   @IsString()
   @ApiProperty({
     description: 'The xnode\'s id',
-    maxLength: 1000,
+    maxLength: 5000,
   })
   id: string;
 
   @IsNotEmpty()
-  @MaxLength(1000)
+  @MaxLength(5000)
   @IsString()
   @ApiProperty({
     description: 'The xnode\'s services',
-    maxLength: 1000,
+    maxLength: 5000,
   })
   services: string;
 }
@@ -192,7 +192,7 @@ export class UpdateXnodeDto {
   @MaxLength(1000)
   @ApiProperty({
     description: 'Id of the Xnode',
-    maxLength: 1000,
+    maxLength: 100,
   })
   xnodeId: string;
 
@@ -201,7 +201,7 @@ export class UpdateXnodeDto {
   @IsString()
   @ApiProperty({
     description: 'The Xnode name',
-    maxLength: 1000,
+    maxLength: 100,
   })
   name: string;
 

--- a/src/xnodes/xnodes.service.ts
+++ b/src/xnodes/xnodes.service.ts
@@ -527,7 +527,7 @@ export class XnodesService {
       throw new Error("Invalid HMAC, is your access token correct?")
     }
   }
-  // TODO: Can get information from XU_URL/node_information/<xnode-unit-token-id>
+  // TODO: Can get information from XU_URL/info/<xnode-unit-token-id>
   //async fetch_unit_information(deployment: ) {
     // STUB
   //}

--- a/src/xnodes/xnodes.service.ts
+++ b/src/xnodes/xnodes.service.ts
@@ -66,6 +66,7 @@ export class XnodesService {
   );
   XU_CONTROLLER_URL = process.env.XU_CONTROLLER_URL;
   XU_CONTROLLER_KEY = process.env.XU_CONTROLLER_KEY;
+  XNODE_API_URL = process.env.XNODE_API_URL;
 
   async createXnode(dataBody: CreateXnodeDto, req: Request) {
     const sessionToken = String(req.headers['x-parse-session-token']);
@@ -343,8 +344,7 @@ export class XnodesService {
             // WalletAddress: user.walletAddress,
             xnodeId: xnodeId,
             xnodeAccessToken: xnodeAccessToken,
-            // XXX: Change this in production and dev.
-            xnodeConfigRemote: "https://dpl-backend-staging.up.railway.app",
+            xnodeConfigRemote: this.XNODE_API_URL,
             nftActivationTime: nftMintDate,
           });
 
@@ -534,9 +534,9 @@ export class XnodesService {
 
   async updateXnode(dataBody: UpdateXnodeDto, req: Request) {
     // TODO: Double check this function works as expected.
-    const accessToken = String(req.headers['x-parse-session-token']);
+    const sessionToken = String(req.headers['x-parse-session-token']);
     const user = await this.openmeshExpertsAuthService.verifySessionToken(
-      accessToken,
+      sessionToken,
     );
 
     const xnodes = await this.prisma.deployment.findFirst({
@@ -566,9 +566,9 @@ export class XnodesService {
   }
 
   async getXnode(dataBody: GetXnodeDto, req: Request) {
-    const accessToken = String(req.headers['x-parse-session-token']);
+    const sessionToken = String(req.headers['x-parse-session-token']);
     const user = await this.openmeshExpertsAuthService.verifySessionToken(
-      accessToken,
+      sessionToken,
     );
 
     return await this.prisma.deployment.findFirst({
@@ -673,9 +673,9 @@ export class XnodesService {
     dataBody: StoreXnodeSigningMessageDataDTO,
     req: Request,
   ) {
-    const accessToken = String(req.headers['x-parse-session-token']);
+    const sessionToken = String(req.headers['x-parse-session-token']);
     const user = await this.openmeshExpertsAuthService.verifySessionToken(
-      accessToken,
+      sessionToken,
     );
 
     const xnodeExists = await this.prisma.xnode.findFirst({


### PR DESCRIPTION
Tested and working integration with Xnode Unit Controller. Not much change was needed but there's also character limit changes and the dpl remote config address is an environment variable per instance of the DPL. These are important for pushServices to work given a slightly larger character count, or for the differing instances of PROD/STAGING dpl-backends which will have different remotes for any Xnodes deployed through them.